### PR TITLE
Add line to results for hands with good mana

### DIFF
--- a/src/components/SectionResults.tsx
+++ b/src/components/SectionResults.tsx
@@ -34,6 +34,10 @@ export default function SectionResults(props: ISectionResults) {
             label={`At most ${props.radChecks.opener.maxLand} Lands`}
           />
           <RadResult
+            total={CommonUtil.percent(props.radOutput.opener.bothLandSuccesses, props.radOutput.simulations)}
+            label={`Between ${props.radChecks.opener.minLand} and ${props.radChecks.opener.maxLand} Lands`}
+          />
+          <RadResult
             total={CommonUtil.percent(props.radOutput.opener.minPlayableSuccesses, props.radOutput.simulations)}
             label={`At least ${props.radChecks.opener.minPlayable} Plays (Early)`}
           />
@@ -59,6 +63,10 @@ export default function SectionResults(props: ISectionResults) {
           <RadResult
             total={CommonUtil.percent(props.radOutput.early.maxLandSuccesses, props.radOutput.simulations)}
             label={`At most ${props.radChecks.early.maxLand} Lands`}
+          />
+          <RadResult
+            total={CommonUtil.percent(props.radOutput.early.bothLandSuccesses, props.radOutput.simulations)}
+            label={`Between ${props.radChecks.early.minLand} and ${props.radChecks.early.maxLand} Lands`}
           />
           <RadResult
             total={CommonUtil.percent(props.radOutput.early.minPlayableSuccesses, props.radOutput.simulations)}
@@ -88,6 +96,10 @@ export default function SectionResults(props: ISectionResults) {
             label={`At most ${props.radChecks.mid.maxLand} Lands`}
           />
           <RadResult
+            total={CommonUtil.percent(props.radOutput.mid.bothLandSuccesses, props.radOutput.simulations)}
+            label={`Between ${props.radChecks.mid.minLand} and ${props.radChecks.mid.maxLand} Lands`}
+          />
+          <RadResult
             total={CommonUtil.percent(props.radOutput.mid.minPlayableSuccesses, props.radOutput.simulations)}
             label={`At least ${props.radChecks.mid.minPlayable} Plays (Early/Mid)`}
           />
@@ -113,6 +125,10 @@ export default function SectionResults(props: ISectionResults) {
           <RadResult
             total={CommonUtil.percent(props.radOutput.late.maxLandSuccesses, props.radOutput.simulations)}
             label={`At most ${props.radChecks.late.maxLand} Total Lands`}
+          />
+          <RadResult
+            total={CommonUtil.percent(props.radOutput.late.bothLandSuccesses, props.radOutput.simulations)}
+            label={`Between ${props.radChecks.late.minLand} and ${props.radChecks.late.maxLand} Lands`}
           />
           <RadResult
             total={CommonUtil.percent(props.radOutput.late.minPlayableSuccesses, props.radOutput.simulations)}

--- a/src/utils/RADSimulator.ts
+++ b/src/utils/RADSimulator.ts
@@ -93,6 +93,10 @@ export class RADSimulator {
       radOutputStage.maxLandSuccesses++;
     }
 
+    if (landCount >= radChecksStage.minLand && landCount <= radChecksStage.maxLand) {
+      radOutputStage.bothLandSuccesses++;
+    }
+
     // Minimum Playables that are castable
     if (playableCount < radChecksStage.minPlayable) {
       success = false;

--- a/src/utils/defaults.ts
+++ b/src/utils/defaults.ts
@@ -315,6 +315,7 @@ export const DEFAULT_RAD_OUTPUT: IRadOutput = {
   opener: {
     minLandSuccesses: 0,
     maxLandSuccesses: 0,
+    bothLandSuccesses: 0,
     minPlayableSuccesses: 0,
     minInteractionSuccesses: 0,
     minBombSuccesses: 0,
@@ -323,6 +324,7 @@ export const DEFAULT_RAD_OUTPUT: IRadOutput = {
   early: {
     minLandSuccesses: 0,
     maxLandSuccesses: 0,
+    bothLandSuccesses: 0,
     minPlayableSuccesses: 0,
     minInteractionSuccesses: 0,
     minBombSuccesses: 0,
@@ -331,6 +333,7 @@ export const DEFAULT_RAD_OUTPUT: IRadOutput = {
   mid: {
     minLandSuccesses: 0,
     maxLandSuccesses: 0,
+    bothLandSuccesses: 0,
     minPlayableSuccesses: 0,
     minInteractionSuccesses: 0,
     minBombSuccesses: 0,
@@ -339,6 +342,7 @@ export const DEFAULT_RAD_OUTPUT: IRadOutput = {
   late: {
     minLandSuccesses: 0,
     maxLandSuccesses: 0,
+    bothLandSuccesses: 0,
     minPlayableSuccesses: 0,
     minInteractionSuccesses: 0,
     minBombSuccesses: 0,

--- a/src/utils/models.ts
+++ b/src/utils/models.ts
@@ -46,6 +46,7 @@ export interface IRadChecks {
 export interface IRadOutputStage {
   minLandSuccesses: number,
   maxLandSuccesses: number,
+  bothLandSuccesses: number,
   minPlayableSuccesses: number,
   minInteractionSuccesses: number,
   minBombSuccesses: number,


### PR DESCRIPTION
### Goal
Add an additional row to the simulator results with the % of hands with 'good' mana. This is defined as `min <= actual <= max` aka "neither flood nor screw". The row displays after the current min/max ones, and reads `Between {min} and {max} Lands`.

### Screenshot
![image](https://user-images.githubusercontent.com/16469565/225116832-fc0f55aa-3fa1-4d7b-8b49-11554d7360a4.png)

### Implementation Notes
I opted to explicitly track it as a new field for simplicity, but this could be computed using the current min/max success. I believe that would be:
```
   100 - minFailures - maxFailures 
= 100 - (100-minSuccess) - (100-maxSuccess)
= minSuccess + maxSuccess - 100
```

### Tech Debt
I worked on this a while ago and was going to take it further by adding way succinctly display screw/good/flood, but decided that was excessive and required some design discussions. I'm hoping I didn't forget about any TODOs from then!